### PR TITLE
fix for typescript and recent react versions

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -82,6 +82,7 @@ export function stringToTokens(
 export function tokensToAST(tokens: ReadonlyArray<Token>): ASTNode[];
 
 export interface MarkdownProps {
+  children?: ReactNode;
   rules?: RenderRules;
   style?: StyleSheet.NamedStyles<any>;
   renderer?: AstRenderer;


### PR DESCRIPTION
credit to https://github.com/iamacup/react-native-markdown-display/issues/176